### PR TITLE
fix: issue with date as invalid date object in invoice V3

### DIFF
--- a/build/config-reference-v3.json
+++ b/build/config-reference-v3.json
@@ -772,7 +772,13 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "date": {
+          "ui:widget": "date"
+        }
+      },
+      "extension": "tt"
     },
     {
       "name": "TradeTrust Invoice v3",
@@ -943,7 +949,15 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "credentialSubject": {
+          "date": {
+            "ui:widget": "date"
+          }
+        }
+      },
+      "extension": "tt"
     }
   ]
 }

--- a/build/goerli/config-v3.json
+++ b/build/goerli/config-v3.json
@@ -772,7 +772,13 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "date": {
+          "ui:widget": "date"
+        }
+      },
+      "extension": "tt"
     },
     {
       "name": "TradeTrust Invoice v3",
@@ -943,7 +949,15 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "credentialSubject": {
+          "date": {
+            "ui:widget": "date"
+          }
+        }
+      },
+      "extension": "tt"
     }
   ]
 }

--- a/build/local/config-v3.json
+++ b/build/local/config-v3.json
@@ -772,7 +772,13 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "date": {
+          "ui:widget": "date"
+        }
+      },
+      "extension": "tt"
     },
     {
       "name": "TradeTrust Invoice v3",
@@ -943,7 +949,15 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "credentialSubject": {
+          "date": {
+            "ui:widget": "date"
+          }
+        }
+      },
+      "extension": "tt"
     }
   ]
 }

--- a/build/rinkeby/config-v3.json
+++ b/build/rinkeby/config-v3.json
@@ -772,7 +772,13 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "date": {
+          "ui:widget": "date"
+        }
+      },
+      "extension": "tt"
     },
     {
       "name": "TradeTrust Invoice v3",
@@ -943,7 +949,15 @@
             "title": "Total"
           }
         }
-      }
+      },
+      "uiSchema": {
+        "credentialSubject": {
+          "date": {
+            "ui:widget": "date"
+          }
+        }
+      },
+      "extension": "tt"
     }
   ]
 }

--- a/fixtures/config/forms/v3/invoice-dns-did.json
+++ b/fixtures/config/forms/v3/invoice-dns-did.json
@@ -164,5 +164,11 @@
         "title": "Total"
       }
     }
-  }
+  },
+  "uiSchema": {
+    "date": {
+      "ui:widget": "date"
+    }
+  },
+  "extension": "tt"
 }

--- a/fixtures/config/forms/v3/invoice.json
+++ b/fixtures/config/forms/v3/invoice.json
@@ -164,5 +164,11 @@
         "title": "Total"
       }
     }
-  }
+  },
+  "uiSchema": {
+    "date": {
+      "ui:widget": "date"
+    }
+  },
+  "extension": "tt"
 }


### PR DESCRIPTION
## Issue Summary

When cloning V3 config file using cli and creating an invoice, there is an error verifying it in tt-web as the date is not using a date widget to input a valid date value.

## Changes
- update V3 config invoice form reference to have the date widget in uiSchema.