### PR TITLE
feat: semantic release

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -19,3 +19,8 @@ jobs:
         run: npm run test
       - name: Build docs
         run: npm run docs
+      - name: Release
+        run: npx semantic-release --branches master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /docs
 .netlify
+dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TradeTrust config
+# TradeTrust Creator configs
 
 Repository to house TradeTrust config schema + various configs used in TradeTrust creator.
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "npx rimraf ./build",
     "generate": "ts-node ./src/generate-config.ts --project tsconfig.json",
     "build": "npm run clean && npm run generate",
+    "dist:cjs": "tsc --project tsconfig.shared.json --module commonjs --target es2015 --outDir dist/cjs",
+    "dist:esm": "tsc --project tsconfig.shared.json --module es2015 --target es2015 --outDir dist/esm",
+    "dist": "npx rimraf ./dist && npm run dist:cjs && npm run dist:esm",
     "docs": "npx typedoc --excludeInternal",
     "start": "npx json-server --watch ./src/response.js --port 4000 --no-cors true",
     "lint": "eslint ./src/*/**.ts",

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from "./updateForm";

--- a/src/shared/updateForm.ts
+++ b/src/shared/updateForm.ts
@@ -1,0 +1,3 @@
+export const updateForm = () => {
+  console.log("update form");
+};

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node"
+  },
+  "include": ["./src/shared/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
build and release `shared` functions to reuse in other repos.
- will shift [updateForm](https://github.com/Open-Attestation/open-attestation/blob/b7a26fedf13e34b022911f01a619eddf1d9ad79e/src/shared/utils/utils.ts#L244-L338) functionalities here in another pr later.
- thereafter should be able to reuse test fixture files here.