### PR TITLE
feat: update form

### DIFF
--- a/src/shared/updateForm.ts
+++ b/src/shared/updateForm.ts
@@ -1,3 +1,120 @@
-export const updateForm = () => {
-  console.log("update form");
+type WalletEncryptedJson = {
+  type: "ENCRYPTED_JSON";
+  encryptedJson: string;
+};
+
+type WalletAws = {
+  type: "AWS_KMS";
+  accessKeyId: string;
+  region: string;
+  kmsKeyId: string;
+};
+
+type Wallet = WalletEncryptedJson | WalletAws;
+
+interface UpdateForm {
+  wallet: Wallet;
+  form: any;
+  documentStoreAddress: string;
+  tokenRegistryAddress: string;
+  dnsVerifiable: string;
+  dnsDid: string;
+  dnsTransferableRecord: string;
+}
+
+export const updateFormV2 = ({
+  wallet,
+  form,
+  documentStoreAddress,
+  tokenRegistryAddress,
+  dnsVerifiable,
+  dnsDid,
+  dnsTransferableRecord,
+}: UpdateForm) => {
+  const { encryptedJson } = wallet as WalletEncryptedJson;
+  const { address } = JSON.parse(encryptedJson);
+
+  if (form.type === "VERIFIABLE_DOCUMENT") {
+    const updatedIssuers = form.defaults.issuers.map((issuer: any) => {
+      if (issuer.identityProof) {
+        if (issuer.identityProof.type === "DNS-TXT") {
+          issuer.documentStore = documentStoreAddress;
+          issuer.identityProof.location = dnsVerifiable;
+        } else if (
+          issuer.identityProof.type === "DNS-DID" ||
+          issuer.identityProof.type === "DID"
+        ) {
+          issuer.id = `did:ethr:0x${address}`;
+          issuer.identityProof.key = `did:ethr:0x${address}#controller`;
+
+          if (issuer.identityProof.type === "DNS-DID") {
+            issuer.identityProof.location = dnsDid;
+          } else if (issuer.identityProof.type === "DID") {
+            delete issuer.identityProof.location;
+          }
+        }
+      }
+      return issuer;
+    });
+    form.defaults.issuers = updatedIssuers;
+  }
+
+  if (form.type === "TRANSFERABLE_RECORD") {
+    const updatedIssuers = form.defaults.issuers.map((issuer: any) => {
+      issuer.tokenRegistry = tokenRegistryAddress;
+      if (issuer.identityProof) {
+        issuer.identityProof.location = dnsTransferableRecord;
+      }
+      return issuer;
+    });
+    form.defaults.issuers = updatedIssuers;
+  }
+
+  return form;
+};
+
+export const updateFormV3 = ({
+  wallet,
+  form,
+  documentStoreAddress,
+  tokenRegistryAddress,
+  dnsVerifiable,
+  dnsDid,
+  dnsTransferableRecord,
+}: UpdateForm) => {
+  const { encryptedJson } = wallet as WalletEncryptedJson;
+  const { address } = JSON.parse(encryptedJson);
+
+  if (form.type === "VERIFIABLE_DOCUMENT") {
+    if (
+      form.defaults.openAttestationMetadata.proof.method === "DOCUMENT_STORE"
+    ) {
+      form.defaults.openAttestationMetadata.proof.value = documentStoreAddress;
+    } else if (form.defaults.openAttestationMetadata.proof.method === "DID") {
+      form.defaults.openAttestationMetadata.proof.value = `did:ethr:0x${address}`;
+    }
+
+    if (
+      form.defaults.openAttestationMetadata.identityProof.type === "DNS-TXT"
+    ) {
+      form.defaults.openAttestationMetadata.identityProof.identifier =
+        dnsVerifiable;
+    } else if (
+      form.defaults.openAttestationMetadata.identityProof.type === "DNS-DID"
+    ) {
+      form.defaults.openAttestationMetadata.identityProof.identifier = dnsDid;
+    } else if (
+      form.defaults.openAttestationMetadata.identityProof.type === "DID"
+    ) {
+      form.defaults.openAttestationMetadata.identityProof.identifier = `did:ethr:0x${address}`;
+    }
+  }
+
+  if (form.type === "TRANSFERABLE_RECORD") {
+    form.defaults.openAttestationMetadata.proof.value = tokenRegistryAddress;
+    form.defaults.openAttestationMetadata.identityProof.identifier =
+      dnsTransferableRecord;
+  }
+
+  return form;
 };

--- a/test/updateForm.test.ts
+++ b/test/updateForm.test.ts
@@ -1,0 +1,238 @@
+import { Wallet } from "ethers";
+import { updateFormV2, updateFormV3 } from "../src/shared/updateForm";
+import v2VerifiableDocumentForm from "../fixtures/config/forms/v2/invoice.json";
+import v2DnsDidForm from "../fixtures/config/forms/v2/invoice-dns-did.json";
+import v2TransferableRecordForm from "../fixtures/config/forms/v2/bill-of-lading.json";
+import v3VerifiableDocumentForm from "../fixtures/config/forms/v3/invoice.json";
+import v3DnsDidForm from "../fixtures/config/forms/v3/invoice-dns-did.json";
+import v3TransferableRecordForm from "../fixtures/config/forms/v3/bill-of-lading.json";
+
+const v2DidForm = {
+  name: "A DID Verifiable Document Form",
+  type: "VERIFIABLE_DOCUMENT",
+  defaults: {
+    $template: {
+      type: "EMBEDDED_RENDERER",
+      name: "CHAFTA_COO",
+      url: "https://generic-templates.openattestation.io",
+    },
+    issuers: [
+      {
+        id: "did:ethr:0x123123123123123123123123123123123123",
+        name: "DEMO DID",
+        revocation: {
+          type: "NONE",
+        },
+        identityProof: {
+          type: "DID",
+          key: "did:ethr:0x123123123123123123123123123123123123#controller",
+          location: "demo-oa.openattestation.com",
+        },
+      },
+    ],
+  },
+}; // putting directly here instead of fixtures, as we don't want to provide any `DID` forms during `npm run build`
+
+const v3DidForm = {
+  name: "A V3 DID Verifiable Document Form",
+  type: "VERIFIABLE_DOCUMENT",
+  defaults: {
+    version: "https://schema.openattestation.com/3.0/schema.json",
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
+    ],
+    type: ["VerifiableCredential", "OpenAttestationCredential"],
+    issuanceDate: "2010-01-01T19:23:24Z",
+    openAttestationMetadata: {
+      template: {
+        type: "EMBEDDED_RENDERER",
+        name: "CHAFTA_COO",
+        url: "https://generic-templates.oa.io",
+      },
+      proof: {
+        type: "OpenAttestationProofMethod",
+        method: "DID",
+        value: "did:ethr:0x123",
+        revocation: {
+          type: "NONE",
+        },
+      },
+      identityProof: {
+        type: "DID",
+        identifier: "demo-oa.openattestation.com",
+      },
+    },
+    credentialSubject: {},
+    issuer: {
+      id: "https://example.com",
+      name: "DEMO DID",
+      type: "OpenAttestationIssuer",
+    },
+  },
+}; // putting directly here instead of fixtures, as we don't want to provide any `DID` forms during `npm run build`
+
+describe("updateFormV2", () => {
+  const wallet = Wallet.fromMnemonic(
+    "tourist quality multiply denial diary height funny calm disease buddy speed gold",
+  );
+  const walletString = JSON.stringify(wallet);
+
+  it("should update the form from a verifiable document correctly", () => {
+    const updatedForm = updateFormV2({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v2VerifiableDocumentForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.issuers[0].identityProof.location,
+    ).toStrictEqual("VerifiableDNS.com");
+    expect(updatedForm.defaults.issuers[0].documentStore).toStrictEqual(
+      "0xabcDocumentStore",
+    );
+  });
+
+  it("should update the form from a DID verifiable document correctly", () => {
+    const updatedForm = updateFormV2({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v2DidForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+
+    expect(updatedForm.defaults.issuers[0].id).toStrictEqual(
+      "did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C",
+    );
+    expect(updatedForm.defaults.issuers[0].identityProof.key).toStrictEqual(
+      "did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C#controller",
+    );
+    expect(
+      updatedForm.defaults.issuers[0].identityProof.location,
+    ).toStrictEqual(undefined);
+  });
+
+  it("should update the form from a DNS-DID verifiable document correctly", () => {
+    const updatedForm = updateFormV2({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v2DnsDidForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(updatedForm.defaults.issuers[0].id).toStrictEqual(
+      "did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C",
+    );
+    expect(updatedForm.defaults.issuers[0].identityProof.key).toStrictEqual(
+      "did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C#controller",
+    );
+    expect(
+      updatedForm.defaults.issuers[0].identityProof.location,
+    ).toStrictEqual("DNSDID.com");
+  });
+
+  it("should update the form from a transferable document correctly", () => {
+    const updatedForm = updateFormV2({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v2TransferableRecordForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.issuers[0].identityProof.location,
+    ).toStrictEqual("TransferableDNS.com");
+    expect(updatedForm.defaults.issuers[0].tokenRegistry).toStrictEqual(
+      "0xabcTokenRegistry",
+    );
+  });
+});
+
+describe("updateFormV3", () => {
+  const wallet = Wallet.fromMnemonic(
+    "tourist quality multiply denial diary height funny calm disease buddy speed gold",
+  );
+  const walletString = JSON.stringify(wallet);
+
+  it("should update the form from a verifiable document correctly", () => {
+    const updatedForm = updateFormV3({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v3VerifiableDocumentForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.openAttestationMetadata.identityProof.identifier,
+    ).toStrictEqual("VerifiableDNS.com");
+    expect(
+      updatedForm.defaults.openAttestationMetadata.proof.value,
+    ).toStrictEqual("0xabcDocumentStore");
+  });
+
+  it("should update the form from a DID verifiable document correctly", () => {
+    const updatedForm = updateFormV3({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v3DidForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.openAttestationMetadata.proof.value,
+    ).toStrictEqual("did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C");
+    expect(
+      updatedForm.defaults.openAttestationMetadata.identityProof.identifier,
+    ).toStrictEqual("did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C");
+  });
+
+  it("should update the form from a DNS-DID verifiable document correctly", () => {
+    const updatedForm = updateFormV3({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v3DnsDidForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.openAttestationMetadata.proof.value,
+    ).toStrictEqual("did:ethr:0x0x906FB815De8976b1e38D9a4C1014a3acE16Ce53C");
+    expect(
+      updatedForm.defaults.openAttestationMetadata.identityProof.identifier,
+    ).toStrictEqual("DNSDID.com");
+  });
+
+  it("should update the form from a transferable document correctly", () => {
+    const updatedForm = updateFormV3({
+      wallet: { type: "ENCRYPTED_JSON", encryptedJson: walletString },
+      form: v3TransferableRecordForm,
+      documentStoreAddress: "0xabcDocumentStore",
+      tokenRegistryAddress: "0xabcTokenRegistry",
+      dnsVerifiable: "VerifiableDNS.com",
+      dnsDid: "DNSDID.com",
+      dnsTransferableRecord: "TransferableDNS.com",
+    });
+    expect(
+      updatedForm.defaults.openAttestationMetadata.identityProof.identifier,
+    ).toStrictEqual("TransferableDNS.com");
+    expect(
+      updatedForm.defaults.openAttestationMetadata.proof.value,
+    ).toStrictEqual("0xabcTokenRegistry");
+  });
+});


### PR DESCRIPTION
- putting `updateFormV2`, `updateFormV3` where it belongs here. these utils were from [OA](https://github.com/Open-Attestation/open-attestation/blob/b7a26fedf13e34b022911f01a619eddf1d9ad79e/src/shared/utils/utils.ts#L232-L338).
- tests ported over wholesale from [here](https://github.com/Open-Attestation/open-attestation/blob/b7a26fedf13e34b022911f01a619eddf1d9ad79e/src/shared/utils/__tests__/utils.test.ts#L470-L610).
- will be removing `updateFormV2`, `updateFormV3` from OA + updating the respective repos (only oa-cli repo is using those [utils](https://github.com/Open-Attestation/open-attestation-cli/blob/bc9c257483ce55fa23e1e7e6e650a69a6975c2f3/src/implementations/config/helpers.ts#L73-L92)).