### PR TITLE
[WIP] Add support for Stability Testnet network

### DIFF
--- a/src/config-v2.schema.json
+++ b/src/config-v2.schema.json
@@ -14,7 +14,8 @@
         "matic",
         "maticmum",
         "xdc",
-        "xdcapothem"
+        "xdcapothem",
+        "stabilitytestnet"
       ]
     },
     "wallet": {

--- a/src/config-v3.schema.json
+++ b/src/config-v3.schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "network": {
       "type": "string",
-      "enum": ["homestead", "local", "goerli", "sepolia", "matic", "maticmum","xdc","xdcapothem"]
+      "enum": ["homestead", "local", "goerli", "sepolia", "matic", "maticmum","xdc","xdcapothem", "stabilitytestnet"]
     },
     "wallet": {
       "oneOf": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,14 @@ import { CHAIN_ID } from "@tradetrust-tt/tradetrust-utils/constants/supportedCha
 // addresses exists as txt-records in respective domains
 export const buildData = [
   {
+    chainId: "20180427" as CHAIN_ID,
+    documentStoreAddress: "0x69E29FA634573BB6b82C01b3FEA3B704488bd853",
+    tokenRegistryAddress: "0x3d23649EB097fa729A8e1e15Fdb37680Caf766F7",
+    dnsVerifiable: "tradetrust-testnet.stabilityprotocol.com",
+    dnsTransferableRecord: "tradetrust-testnet.stabilityprotocol.com",
+    dnsDid: "tradetrust-testnet.stabilityprotocol.com",
+  },
+  {
     chainId: "51" as CHAIN_ID,
     documentStoreAddress: "0x268852277C0eED5A9999B41b0FdbA0443De76475",
     tokenRegistryAddress: "0x1a378fEEc3ed9B63B872B11561FCf19f6d2CE793",


### PR DESCRIPTION
## Summary

This PR adds support for [Stability Testnet](https://github.com/stabilityprotocol/) network.

This PR is pending other PR related to the TradeTrust pkg to update the `package.json` dependency: https://github.com/TradeTrust/tradetrust-utils/pull/32

## Issues
NA

For further information, please reach the following email: kerk@stabilityprotocol.com